### PR TITLE
feat: functional refactoring

### DIFF
--- a/2018/day03.test.ts
+++ b/2018/day03.test.ts
@@ -2,22 +2,22 @@ import { expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import { day3_part1, day3_part2 } from "./day03";
 
-test("day3 part1 test", async() => {
+test("day3 part 1 test", async() => {
 	expect(day3_part1("#1 @ 1,3: 4x4\n#2 @ 3,1: 4x4\n#3 @ 5,5: 2x2")).toBe(4);
 })
 
-test("day3 par1 real", async() => {
-	const input = await fs.readFile("inputs/day03.txt", "utf-8");
+test("day3 part 1 real", async() => {
+	const input = await fs.readFile("./2018/inputs/day03.txt", "utf-8");
 
 	expect(day3_part1(input)).toBe(116491);
 })
 
-test("day3 part2 test", async() => {
+test("day3 part 2 test", async() => {
 	expect(day3_part2("#1 @ 1,3: 4x4\n#2 @ 3,1: 4x4\n#3 @ 5,5: 2x2")).toBe(3);
 })
 
-test("day3 par2 real", async() => {
-	const input = await fs.readFile("inputs/day03.txt", "utf-8");
+test("day3 part 2 real", async() => {
+	const input = await fs.readFile("./2018/inputs/day03.txt", "utf-8");
 
 	expect(day3_part2(input)).toBe(707);
 })

--- a/2018/day04.test.ts
+++ b/2018/day04.test.ts
@@ -6,18 +6,18 @@ test("day4 part1 test", async() => {
 	expect(day4_part1("[1518-11-01 00:05] falls asleep\n[1518-11-01 00:25] wakes up\n[1518-11-01 00:30] falls asleep\n[1518-11-01 00:55] wakes up\n[1518-11-01 23:58] Guard #99 begins shift\n[1518-11-02 00:40] falls asleep\n[1518-11-02 00:50] wakes up\n[1518-11-03 00:05] Guard #10 begins shift\n[1518-11-03 00:24] falls asleep\n[1518-11-03 00:29] wakes up\n[1518-11-01 00:00] Guard #10 begins shift\n[1518-11-04 00:02] Guard #99 begins shift\n[1518-11-04 00:36] falls asleep\n[1518-11-04 00:46] wakes up\n[1518-11-05 00:03] Guard #99 begins shift\n[1518-11-05 00:45] falls asleep\n[1518-11-05 00:55] wakes up")).toBe(240);
 })
 
-test("day4 par1 real", async() => {
-	const input = await fs.readFile("inputs/day04.txt", "utf-8");
-
-	expect(day4_part1(input)).toBe(106710);
-})
-
 test("day4 part2 test", async() => {
 	expect(day4_part2("[1518-11-01 00:05] falls asleep\n[1518-11-01 00:25] wakes up\n[1518-11-01 00:30] falls asleep\n[1518-11-01 00:55] wakes up\n[1518-11-01 23:58] Guard #99 begins shift\n[1518-11-02 00:40] falls asleep\n[1518-11-02 00:50] wakes up\n[1518-11-03 00:05] Guard #10 begins shift\n[1518-11-03 00:24] falls asleep\n[1518-11-03 00:29] wakes up\n[1518-11-01 00:00] Guard #10 begins shift\n[1518-11-04 00:02] Guard #99 begins shift\n[1518-11-04 00:36] falls asleep\n[1518-11-04 00:46] wakes up\n[1518-11-05 00:03] Guard #99 begins shift\n[1518-11-05 00:45] falls asleep\n[1518-11-05 00:55] wakes up")).toBe(4455);
 })
 
-test("day4 part2 real", async() => {
-	const input = await fs.readFile("inputs/day04.txt", "utf-8");
+test("day4 part1 real", async() => {
+	const input = await fs.readFile("./2018/inputs/day04.txt", "utf-8");
 
-	expect(day4_part2(input)).toBe(707);
+	expect(day4_part1(input)).toBe(106710);
+})
+
+test("day4 part2 real", async() => {
+	const input = await fs.readFile("./2018/inputs/day04.txt", "utf-8");
+
+	expect(day4_part2(input)).toBe(10491);
 })

--- a/2018/day04.ts
+++ b/2018/day04.ts
@@ -1,104 +1,106 @@
-// Find the guard that has the most minutes asleep
-// What minute does that guard spend asleep the most?
-type GuardInfo = {
-	accLen: number,
-	sleepMap: Map<number, number>
+import invariant from "./invariant";
+
+type SleepPeriod = {
+  id: number;
+  start: number;
+  end: number;
 };
 
-function addNewGuard(guards: Map<number, GuardInfo>, id: number) {
-	if (!guards.has(id)) {
-		let guard: GuardInfo = {
-			accLen : 0,
-			sleepMap : new Map<number, number>()
-		}
-		guards.set(id, guard);
-	}
-	return id;
+type GuardSleepData = {
+  id: number;
+  minute: number;
+  times: number;
+};
+
+
+// Parse guard ID from message
+const parseId = (message: string): number => 
+  parseInt(message.match(/Guard #(\d+) begins shift/)?.[1] || '0');
+
+// Parse input lines into sleep periods grouped by guard ID
+const parseInputLines = (inputLines: string[]): Record<number, SleepPeriod[]> => {
+  let currentId = 0;
+  let sleepStart = 0;
+  const result: SleepPeriod[] = [];
+  
+  inputLines
+    .sort()
+    .forEach(line => {
+      const [, minuteStr, message] = line.match(/\[\d{4}-\d{2}-\d{2} \d{2}:(\d{2})\] (.+)/) || [];
+	  invariant(minuteStr !== undefined, "올바르지 않은 입력입니다:" + line);
+	  invariant(message !== undefined, "올바르지 않은 입력입니다:" + line);
+      const minute = parseInt(minuteStr);
+      
+      if (message === "falls asleep") {
+        sleepStart = minute;
+      } else if (message === "wakes up") {
+        result.push({ id: currentId, start: sleepStart, end: minute });
+      } else {
+        currentId = parseId(message);
+      }
+    });
+  
+  return Object.groupBy(result, period => period.id) as Record<number, SleepPeriod[]>;
+};
+
+// Calculate sleep duration
+const duration = ({ start, end }: SleepPeriod): number => end - start;
+
+// Find guard with most total sleep time
+const topId = (sleepById: Record<number, SleepPeriod[]>): number => {
+  const guardTotals = Object.entries(sleepById)
+    .map(([id, sleepList]) => ({
+      id: parseInt(id),
+      total: sleepList.map(duration).reduce((sum, dur) => sum + dur, 0)
+    }));
+  
+  const maxTotal = Math.max(...guardTotals.map(g => g.total));
+  const result = guardTotals.find(g => g.total === maxTotal);
+  invariant(result !== undefined, "maxTotal을 찾을 수 없습니다")
+  return result.id;
+};
+
+// Find most frequent sleep minute for a guard
+const mostSleepMinute = (id: number, sleepList: SleepPeriod[]): GuardSleepData => {
+  const allMinutes = sleepList.flatMap(({ start, end }) => 
+    Array.from({ length: end - start }, (_, i) => start + i)
+  );
+  
+  const frequencies = allMinutes.reduce((freq, minute) => {
+    freq[minute] = (freq[minute] || 0) + 1;
+    return freq;
+  }, {} as Record<number, number>);
+  
+  const maxTimes = Math.max(...Object.values(frequencies));
+  const minute = parseInt(Object.entries(frequencies)
+    .find(([_, times]) => times === maxTimes)![0]);
+  
+  return { id, minute, times: maxTimes };
+};
+
+// Find guard with highest sleep frequency on any minute
+const mostSleepGuard = (sleepById: Record<number, SleepPeriod[]>): GuardSleepData => {
+  const guardData = Object.entries(sleepById)
+    .map(([id, sleepList]) => mostSleepMinute(parseInt(id), sleepList));
+  
+  const maxTimes = Math.max(...guardData.map(g => g.times));
+  return guardData.find(g => g.times === maxTimes)!;
+};
+
+// Main export functions
+export function day4_part1(input: string): number {
+  const sleepById = parseInputLines(input.split("\n"));
+
+  const id = topId(sleepById);
+  const top = sleepById[id];
+  invariant(top !== undefined, "topId를 찾지 못했습니다.");
+  const result = mostSleepMinute(id, top);
+  return result.id * result.minute;
 }
 
-function recordSleep(guards: Map<number, GuardInfo>, id: number, start: number, end: number) {
-	let guard = guards.get(id);
-	if (typeof guard === "undefined") {
-		throw new Error(`Guard ${id} not found`);
-	} else {
-		let sleepMap = guard.sleepMap;
-		if (typeof sleepMap === "undefined") {
-			throw new Error(`Guard ${id} does not have sleep map`);
-		} else {
-			for (let i = start; i < end; i++) {
-				const count = guard.sleepMap.get(i) || 0;
-				guard.sleepMap.set(i, count + 1);
-			}
-		}
-		guard.accLen += end;
-		guard.accLen -= start;
-	}
-}
+export function day4_part2(input: string): number {
+  const sleepById = parseInputLines(input.split("\n"));
 
-export function day4_part1(input: string) {
-	const data = input.split("\n").sort();
-
-	let guards: Map<number, GuardInfo> = new Map();
-	let guardID: number = 0;
-	let start: number = 0;
-
-	for (const line of data) {
-		if (line.indexOf("#") > 0) {
-			guardID = addNewGuard(guards, parseInt(line.slice(line.indexOf("#") + 1)));
-		} else if (line.indexOf("fall") > 0){
-			start = parseInt(line.slice(line.indexOf(":") + 1));
-		} else {
-			recordSleep(guards, guardID, start, parseInt(line.slice(line.indexOf(":") + 1)));
-		}
-	}
-	// find id of most slept guard
-	let mostSlept: number = 0;
-	let sleeplength: number = 0;
-	let mostCommon: number = 0;
-	let repTime: number = 0;
-	guards.forEach((guard: GuardInfo, id: number) => {
-		if (guard.accLen > sleeplength) {
-			mostSlept = id;
-			sleeplength = guard.accLen;
-			guard.sleepMap.forEach((count: number, minute: number)=> {
-				if (repTime < count) {
-					repTime = count;
-					mostCommon = minute;
-				}
-			})
-		}
-	})
-	return mostSlept * mostCommon ;
-}
-
-export function day4_part2(input: string) {
-		const data = input.split("\n").sort();
-
-	let guards: Map<number, GuardInfo> = new Map();
-	let guardID: number = 0;
-	let start: number = 0;
-
-	for (const line of data) {
-		if (line.indexOf("#") > 0) {
-			guardID = addNewGuard(guards, parseInt(line.slice(line.indexOf("#") + 1)));
-		} else if (line.indexOf("fall") > 0){
-			start = parseInt(line.slice(line.indexOf(":") + 1));
-		} else {
-			recordSleep(guards, guardID, start, parseInt(line.slice(line.indexOf(":") + 1)));
-		}
-	}
-	// find id of most common minute and id
-	let mostSlept: number = 0;
-	let mostCommon: number = 0;
-	let repTime: number = 0;
-	guards.forEach((guard: GuardInfo, id:number) => {
-		guard.sleepMap.forEach((count: number, minute: number) => {
-			if (count > repTime) {
-				repTime = count;
-				mostCommon = minute;
-				mostSlept = id;
-			}
-		})
-	})
-	return mostSlept * mostCommon ;
+  const result = mostSleepGuard(sleepById);
+  return result.id * result.minute;
 }

--- a/2018/day05.test.ts
+++ b/2018/day05.test.ts
@@ -11,7 +11,7 @@ test("day5 part1 result test", async() => {
 })
 
 test("day5 part1 real", async() => {
-	const input = await fs.readFile("inputs/day05.txt", "utf-8");
+	const input = await fs.readFile("./2018/inputs/day05.txt", "utf-8");
 
 	expect(day5_part1(input)).toBe(10878);
 })
@@ -21,7 +21,8 @@ test("day5 part2 test", async() => {
 })
 
 test("day5 part2 real", async() => {
-	const input = await fs.readFile("inputs/day05.txt", "utf-8");
+	const input = await fs.readFile("./2018/inputs/day05.txt", "utf-8");
 
+	
 	expect(day5_part2(input)).toBe(6874);
 })

--- a/2018/day05.ts
+++ b/2018/day05.ts
@@ -1,58 +1,46 @@
-function reactPolymerMethod1(input: string) {
-	const lowerUpper = Array.from({ length: 26 }, (_, i) => {
-		const lower = String.fromCharCode(97 + i);
-		const upper = String.fromCharCode(65 + i);
-		return `${lower}${upper}`;
-	})
-	const upperLower = Array.from({ length: 26 }, (_, i) => {
-		const upper = String.fromCharCode(65 + i);
-		const lower = String.fromCharCode(97 + i);
-		return `${upper}${lower}`
-	})
-	const pattern = [...lowerUpper, ...upperLower];
-	const regexp = new RegExp(pattern.join("|"), "");
-
-	let prevLength = input.length;
-	do {
-		prevLength = input.length;
-		input = input.replace(regexp, "");
-	} while (prevLength !== input.length)
-
-	return input;
+// Key insight from Clojure: use ASCII difference to detect reactive pairs
+function canReact(a: string, b: string): boolean {
+  return Math.abs(a.charCodeAt(0) - b.charCodeAt(0)) === 32;
 }
 
-function reactPolymerMethod2(input: string) {
-	let stack: string[] = [];
-	for (let char of input) {
-		const last = stack.at(stack.length - 1);
-		if (last && last !== char && last.toLowerCase() === char.toLowerCase()) {
-			stack.pop();
-		} else {
-			stack.push(char);
-		}
-	}
-	return stack.join('');
+function reactPolymer(input: string): string {
+  const stack: string[] = [];
+  
+  for (const char of input) {
+    const last = stack[stack.length - 1];
+    if (last && canReact(last, char)) {
+      stack.pop();
+    } else {
+      stack.push(char);
+    }
+  }
+  
+  return stack.join('');
 }
 
-export function day5_part1(input: string) {
-	// const result1 = reactPolymerMethod1(input); // 3.42s
-	const result2 = reactPolymerMethod2(input); // 11.47ms
-	// console.log(result2);
-	return result2.length;
+// Helper function to remove all instances of a character (both cases)
+function removeChar(input: string, char: string): string {
+  const lower = char.toLowerCase();
+  const upper = char.toUpperCase();
+  
+  return Array.from(input)
+    .filter(c => c !== lower && c !== upper)
+    .join('');
 }
 
-export function day5_part2(input: string) {
-	let minLen = input.length;
-	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+export function day5_part1(input: string): number {
+  return reactPolymer(input).length;
+}
 
-	for (const c of alphabet) {
-		const pattern = c + "|" + c.toLowerCase();
-		const regexp = new RegExp(pattern, "g");
-		const removedstring = input.replace(regexp, "");
-		const fullyReactedString = reactPolymerMethod2(removedstring);
-
-		if (minLen > fullyReactedString.length)
-			minLen = fullyReactedString.length;
-	}
-	return minLen;
+export function day5_part2(input: string): number {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  let minLength = input.length;
+  
+  for (const char of alphabet) {
+    const filtered = removeChar(input, char);
+    const reacted = reactPolymer(filtered);
+    minLength = Math.min(minLength, reacted.length);
+  }
+  
+  return minLength;
 }

--- a/2018/invariant.ts
+++ b/2018/invariant.ts
@@ -1,0 +1,48 @@
+const isProduction: boolean = process.env.NODE_ENV === 'production';
+const prefix: string = 'Invariant failed';
+
+/**
+ * `invariant` is used to [assert](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) that the `condition` is [truthy](https://github.com/getify/You-Dont-Know-JS/blob/bdbe570600d4e1107d0b131787903ca1c9ec8140/up%20%26%20going/ch2.md#truthy--falsy).
+ *
+ * 💥 `invariant` will `throw` an `Error` if the `condition` is [falsey](https://github.com/getify/You-Dont-Know-JS/blob/bdbe570600d4e1107d0b131787903ca1c9ec8140/up%20%26%20going/ch2.md#truthy--falsy)
+ *
+ * 🤏 `message`s are not displayed in production environments to help keep bundles small
+ *
+ * @example
+ *
+ * ```ts
+ * const value: Person | null = { name: 'Alex' };
+ * invariant(value, 'Expected value to be a person');
+ * // type of `value`` has been narrowed to `Person`
+ * ```
+ */
+export default function invariant(
+  condition: any,
+  // Not providing an inline default argument for message as the result is smaller
+  /**
+   * Can provide a string, or a function that returns a string for cases where
+   * the message takes a fair amount of effort to compute
+   */
+  message?: string | (() => string),
+): asserts condition {
+  if (condition) {
+    return;
+  }
+  // Condition not passed
+
+  // In production we strip the message but still throw
+  if (isProduction) {
+    throw new Error(prefix);
+  }
+
+  // When not in production we allow the message to pass through
+  // *This block will be removed in production builds*
+
+  const provided: string | undefined = typeof message === 'function' ? message() : message;
+
+  // Options:
+  // 1. message provided: `${prefix}: ${provided}`
+  // 2. message not provided: prefix
+  const value: string = provided ? `${prefix}: ${provided}` : prefix;
+  throw new Error(value);
+}


### PR DESCRIPTION
명령적 스타일이 성능은 괜찮습니다만. 매개변수로 넘긴 값을 변경한다거나 하는 패턴은 코드 간에 결합을 늘려서 객체지향이든 함수형이든 유지보수를 어렵게 하는 패턴입니다. (함수 안을 계속 들여다봐야 하는...)

그래서 저의 함수형 스타일로 리팩토링을 하면서도, 성능 훼손이 너무 심각하지는 않도록 했습니다. (사실 함수 안에서 for문을 쓰는 것도 값을 변경하지만 않으면 크게 문제될 것은 없습니다. js에서는 파이프라인 메서드가 돌 때마다 중간 배열이 생겨서 메모리 이슈도 있고요)

다시 한 번 느끼지만 정규표현식의 힘은 위대하고, 파싱과 계산은 분리하는 게 좋다는 교훈이라 할까요. 파싱을 분리하지 않는 게 성능상으로는 더 좋지만, 파싱을 해야 재사용하기도 편하고, 데이터도 명확하게 보이는 장점이 있습니다.

여기서는 제가 invariant 라는 친구를 썼는데 실무에서는 보통 schema를 씁니다. (typebox 같은) 물론 schema가 성능은 훨씬 더 느리죠.